### PR TITLE
updated the plugin to the new build form and removed the git dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,10 +39,10 @@ BrowserSyncWatcher.prototype.extensions = ['css'];
 // all the files that have been updated, or better: It returns all updated
 // files with given extensions if those are the only files that have been updated.
 // otherwise it will return an empty array.
-BrowserSyncWatcher.prototype.updateCache = function(srcPaths, destDir) {
+BrowserSyncWatcher.prototype.build = function() {
   var files = [];
-  for (var i = 0; i < srcPaths.length; i++) {
-    var tmpFiles = glob.sync(path.join(srcPaths[i], '/**/*'), { nodir: true });
+  for (var i = 0; i < this.inputPaths.length; i++) {
+    var tmpFiles = glob.sync(path.join(this.inputPaths[i], '/**/*'), { nodir: true });
     for (var j = 0; j < tmpFiles.length; j++) {
       var fileEnding = '.' + this.extensions[0];
       // if a filename does not end with the specified fileEnding then reload

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
   },
   "homepage": "https://github.com/Globegitter/broccoli-browser-sync#readme",
   "dependencies": {
-    "broccoli-caching-writer": "git+https://github.com/Globegitter/broccoli-caching-writer.git#patch-1",
-    "browser-sync": "2.17.0",
-    "glob": "7.1.0"
+    "broccoli-caching-writer": "^3.0.3",
+    "browser-sync": "^2.18.5",
+    "glob": "^7.1.1"
   },
   "devDependencies": {
     "eslint": "3.7.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "broccoli-browser-sync-bv",
+  "name": "broccoli-browser-sync",
   "version": "1.0.0",
-  "description": "BrowserSync for Broccoli.js - upgraded to the new plugin model",
+  "description": "BrowserSync for Broccoli.js",
   "main": "index.js",
   "scripts": {
     "lint": "node ./node_modules/eslint/bin/eslint.js index.js",
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/bvellacott/broccoli-browser-sync.git"
+    "url": "git+https://github.com/Globegitter/broccoli-browser-sync.git"
   },
   "keywords": [
     "broccoli",
@@ -26,9 +26,9 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/bvellacott/broccoli-browser-sync/issues"
+    "url": "https://github.com/Globegitter/broccoli-browser-sync/issues"
   },
-  "homepage": "https://github.com/bvellacott/broccoli-browser-sync#readme",
+  "homepage": "https://github.com/Globegitter/broccoli-browser-sync#readme",
   "dependencies": {
     "broccoli-caching-writer": "^3.0.3",
     "browser-sync": "^2.18.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "broccoli-browser-sync",
-  "version": "1.0.2",
-  "description": "BrowserSync for Broccoli.js",
+  "name": "broccoli-browser-sync-bv",
+  "version": "1.0.0",
+  "description": "BrowserSync for Broccoli.js - upgraded to the new plugin model",
   "main": "index.js",
   "scripts": {
     "lint": "node ./node_modules/eslint/bin/eslint.js index.js",
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Globegitter/broccoli-browser-sync.git"
+    "url": "git+https://github.com/bvellacott/broccoli-browser-sync.git"
   },
   "keywords": [
     "broccoli",
@@ -21,13 +21,14 @@
   ],
   "author": "Markus Padourek",
   "contributors": [
+    "Markus Padourek <markus.padourek@gmail.com> (https://github.com/Globegitter)",
     "Michael Laccetti <michael@laccetti.com> (https://laccetti.com/)"
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/Globegitter/broccoli-browser-sync/issues"
+    "url": "https://github.com/bvellacott/broccoli-browser-sync/issues"
   },
-  "homepage": "https://github.com/Globegitter/broccoli-browser-sync#readme",
+  "homepage": "https://github.com/bvellacott/broccoli-browser-sync#readme",
   "dependencies": {
     "broccoli-caching-writer": "^3.0.3",
     "browser-sync": "^2.18.5",

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
   },
   "homepage": "https://github.com/Globegitter/broccoli-browser-sync#readme",
   "dependencies": {
-    "broccoli-caching-writer": "^3.0.3",
-    "browser-sync": "^2.18.5",
-    "glob": "^7.1.1"
+    "broccoli-caching-writer": "3.0.3",
+    "browser-sync": "2.18.5",
+    "glob": "7.1.1"
   },
   "devDependencies": {
     "eslint": "3.7.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "broccoli-browser-sync",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "BrowserSync for Broccoli.js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hi - I noticed I couldn't use this plugin with the latest version of broccoli so I updated the plugin to use the latest version of broccoli-caching-writer. Seemed to work fine :)